### PR TITLE
Fix mobile alignment issues with header and footer

### DIFF
--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -46,11 +46,20 @@
   max-width: var(--content-width);
   margin: var(--space-xl) auto 0;
   padding: var(--space-lg) var(--space-md);
-  border-top: 1px solid var(--border-color);
   font-family: var(--font-ui);
   display: flex;
   justify-content: space-between;
   align-items: center;
+  position: relative;
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: var(--space-md);
+    right: var(--space-md);
+    border-top: 1px solid var(--border-color);
+  }
 }
 
 .footer-logo {
@@ -257,6 +266,11 @@
 
   .site-footer {
     padding: var(--space-lg) var(--space-sm);
+
+    &::before {
+      left: var(--space-sm);
+      right: var(--space-sm);
+    }
   }
 }
 
@@ -275,6 +289,11 @@
     padding: var(--space-lg) var(--space-sm);
     flex-direction: column;
     gap: var(--space-md);
+
+    &::before {
+      left: var(--space-sm);
+      right: var(--space-sm);
+    }
   }
 
   .footer-logo {

--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -249,9 +249,20 @@
   font-size: 0.95em;
 }
 
-/* Responsive navigation */
+/* Responsive navigation and footer */
+@media (max-width: 768px) {
+  .site-nav {
+    padding: 0 var(--space-sm);
+  }
+
+  .site-footer {
+    padding: var(--space-lg) var(--space-sm);
+  }
+}
+
 @media (max-width: 480px) {
   .site-nav {
+    padding: 0 var(--space-sm);
     flex-direction: column;
     align-items: flex-start;
   }
@@ -261,6 +272,7 @@
   }
 
   .site-footer {
+    padding: var(--space-lg) var(--space-sm);
     flex-direction: column;
     gap: var(--space-md);
   }


### PR DESCRIPTION
- Update header/nav horizontal padding to match main content on narrow screens (24px → 16px at 768px and 480px breakpoints)
- Update footer horizontal padding to match main content, ensuring the border-top divider respects page margins instead of running full width